### PR TITLE
export_without_equal

### DIFF
--- a/srcs/ft_export.c
+++ b/srcs/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: jiylee <jiylee@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/17 14:13:20 by seojeong          #+#    #+#             */
-/*   Updated: 2021/07/02 17:35:37 by mac              ###   ########.fr       */
+/*   Updated: 2021/07/10 16:10:31 by seojeong         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,8 +31,6 @@ void			print_quote(char *str, int fd)
 		while (str[i])
 			i++;
 		write(fd, str, ++i);
-		write(fd, "=", 1);
-		write(fd, "\"\"", 2);
 	}
 }
 


### PR DESCRIPTION
- ft_export.c
    "export xxxxxxx" 와 같이 끝에 key의 끝에 '='이나 'value'가 오지 않는 경우, (아래 보기 중 1)에 해당하는 경우) "export"로 환경변수 목록을 출력했을 때 "declare -x xxxxxxx"로 나오게끔 수정하였습니다.
    
    1) export xxxxxx => declare -x xxxxxx
    2) export yyyyyy= => declare -x yyyyyy=""
    3) export zzzzzz=hello => declare -x zzzzzz="hello"